### PR TITLE
Fixes for arm64 build

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,18 +3,38 @@
 set -x
 set -o xtrace -o nounset -o pipefail -o errexit
 
+case "$target_platform" in
+    linux-64) CARGO_BUILD_TARGET=x86_64-unknown-linux-gnu ;;
+    linux-aarch64) CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu ;;
+    linux-ppc64le) CARGO_BUILD_TARGET=powerpc64le-unknown-linux-gnu ;;
+    win-64) CARGO_BUILD_TARGET=x86_64-pc-windows-msvc ;;
+    osx-64) CARGO_BUILD_TARGET=x86_64-apple-darwin;;
+    osx-arm64) CARGO_BUILD_TARGET=aarch64-apple-darwin;;
+    *) echo "unknown target_platform $target_platform" ; exit 1 ;;
+esac
+export CARGO_BUILD_TARGET
+
 SOEXT=so
 if [ "$(uname)" == "Darwin" ]; then
     SOEXT=dylib
 fi
 
-$PYTHON -m pip install --no-deps --ignore-installed -vv .
-
 cp include/sourmash.h ${PREFIX}/include/
 
 cargo build --release
+
+## A bit of an workaround, but make other parts of the script more consistent
+cp -a target/${CARGO_BUILD_TARGET}/release/libsourmash.${SOEXT} target/release/libsourmash.${SOEXT}
+cp -a target/${CARGO_BUILD_TARGET}/release/libsourmash.a target/release/libsourmash.a
+
 cp target/release/libsourmash.a ${PREFIX}/lib/
 cp target/release/libsourmash.${SOEXT} ${PREFIX}/lib/
+
+## This will work on currently unreleased sourmash, wait for 4.3.0+
+#export NO_BUILD=1
+#export DYLD_LIBRARY_PATH=${PREFIX}/lib
+
+$PYTHON -m pip install --no-deps --ignore-installed -vv .
 
 mkdir -p ${PREFIX}/lib/pkgconfig
 cat > ${PREFIX}/lib/pkgconfig/sourmash.pc <<"EOF"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   entry_points:
     - sourmash = sourmash.__main__:main
-  number: 3
+  number: 4
   missing_dso_whitelist:   # [osx]
     - /usr/lib/libresolv.9.dylib  # [osx]
   skip: true  # [py<38]
@@ -24,6 +24,7 @@ requirements:
     - {{ compiler('c') }}              # [not win]
     - {{ compiler('m2w64_c') }}        # [win]
     - rust >=1.48.0
+    - rust-std-aarch64-apple-darwin        # [target_platform == 'osx-arm64']
   host:
     - python
     - pip


### PR DESCRIPTION
Turns out #27 was broken, because it used the Rust target for `x86_64` instead of `arm64`. This is a stopgap for fixing that, while the next sourmash is not released and include some niceties for simplifying the `recipe/build.sh` script.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.